### PR TITLE
fixed relative links to absolute on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A GeoServer REST API client influenced by HTTPX
 `geoserverx` allows `Sync`, `Async` as well as `CLI` Capabilities to talk to your GeoServer REST APIs which makes it ideal to be used in software development project which relies on content of GeoServer. 
 
 Here is a simplistic view of how geoserverx works under the hood
-![architecture](/docs/assets/images/arch.png "architecture")
+![architecture](https://raw.githubusercontent.com/geobeyond/geoserverx/refs/heads/main/docs/assets/images/arch.png "architecture")
 
 
 
@@ -20,4 +20,4 @@ Please open new issue if you want to report any bug or send feature request
 ### Running on local
 `geoserverx` is built with [poetry](https://python-poetry.org/) and it uses following dependencies and dev-dependencies
 
-![layout](/docs/assets/images/layout.png "layout")
+![layout]([/docs/assets/images/layout.png](https://raw.githubusercontent.com/geobeyond/geoserverx/refs/heads/main/docs/assets/images/layout.png) "layout")


### PR DESCRIPTION
Current https://pypi.org/project/geoserverx/ description have broken images link, I have fixed it in this PR